### PR TITLE
fix mutation of `find_command`

### DIFF
--- a/lua/telescope/_extensions/recent-files.lua
+++ b/lua/telescope/_extensions/recent-files.lua
@@ -145,10 +145,11 @@ local recent_files = function(opts)
 
   opts.entry_maker = opts.entry_maker or make_entry.gen_from_file(opts)
 
-  table.remove(find_command, 1)
+  local args = vim.deepcopy(find_command)
+  table.remove(args, 1)
   local job = require("plenary.job"):new {
     command = command,
-    args = find_command,
+    args = args,
     cwd = opts.cwd,
     writer = opts.writer,
     enable_recording = true,


### PR DESCRIPTION
Turns out the setup config didn't really fix my issue from #2 so I looked into it again. 
This will fixes the issue of the plugin eating away at the `find_command` when the `find_command` is passed as a variable. :)