### PR TITLE
Async rewrite

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,6 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"
+call_parentheses = "None"

--- a/README.md
+++ b/README.md
@@ -1,42 +1,52 @@
 # telescope-recent-files
 
-An extension for telescope.nvim that combines the results from builtin.oldfiles({cwd_only = true}) with builtin.find_files
+An extension for telescope.nvim that combines the results from builtin.oldfiles({ cwd_only = true }) with builtin.find_files
 
 In other words, it searches for files in the current directory, and displays files in order of how recently they were opened.
 
 # Setup
 
 Lazy:
-```
+```lua
 {
- 'nvim-telescope/telescope.nvim',
- tag = '0.1.5',
- dependencies = {
-   'mollerhoj/telescope-recent-files.nvim',
- },
- config = function()
-   require("telescope").load_extension("recent-files")
- end
-},
+  'nvim-telescope/telescope.nvim',
+  tag = '0.1.8',
+  dependencies = {
+    'nvim-lua/plenary.nvim'
+    'mollerhoj/telescope-recent-files.nvim',
+  },
+  config = function()
+    require('telescope').load_extension('recent-files')
 
--- A keymap
-vim.keymap.set('n', '<leader>f', function()
-  require('telescope').extensions['recent-files'].recent_files({})
-end, { noremap = true, silent = true })
+    -- Example keymap:
+    vim.keymap.set('n', '<C-p>', require('telescope').extensions['recent-files'].recent_files, { desc = 'Search Files' })
+  end
+},
+```
+
+# Options
+
+The following options can be specified (default values are given):
+```lua
+{
+  cwd = nil, -- if unspecified, current directory is used
+  include_current_file = false,
+  -- any other options accepted by builtin.oldfiles or builtin.find_files are also accepted
+}
 ```
 
 # Alternatives
 
 I made this because I couldn't find a plugin that did exactly what I needed.
 
-I would suggest this functionality be builtin to telescope (It would be quite simple, I would be happy to make a PR).
+I would suggest this functionality be built into Telescope (it would be quite simple, I would be happy to make a PR).
 
 But based on this discussion, https://github.com/nvim-telescope/telescope.nvim/issues/2109, it seems the maintainers doesn't want it.
 
-There are other plugins that tackles this, but have their issues:
+There are other plugins that tackle this, but they have their issues:
 
-- https://github.com/danielfalk/smart-open.nvim (Depends on a sqlite database, and does not integrate with neovims native oldfiles)
-- https://github.com/nvim-telescope/telescope-frecency.nvim (Does not seem to load the oldfiles either?)
+- https://github.com/danielfalk/smart-open.nvim (depends on a sqlite database, and does not integrate with Neovim's native oldfiles)
+- https://github.com/nvim-telescope/telescope-frecency.nvim (does not seem to load the oldfiles either?)
 
 # Run on startup
 
@@ -44,13 +54,12 @@ The first thing I do is usually open a file within the current project I'm worki
 
 Thus, I've set this to run on startup:
 
-```
-vim.api.nvim_create_autocmd('VimEnter',{
-  callback=function()
+```lua
+vim.api.nvim_create_autocmd('VimEnter', {
+  callback = function()
     if vim.fn.argc() == 0 then
-      require('telescope').extensions['recent-files'].recent_files({})
+      require('telescope').extensions['recent-files'].recent_files()
     end
   end
 })
 ```
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An extension for telescope.nvim that combines the results from builtin.oldfiles(
 
 In other words, it searches for files in the current directory, and displays files in order of how recently they were opened.
 
-# Setup
+## Setup
 
 Lazy:
 ```lua
@@ -24,7 +24,7 @@ Lazy:
 },
 ```
 
-# Options
+## Options
 
 The following options can be specified (default values are given):
 ```lua
@@ -35,7 +35,7 @@ The following options can be specified (default values are given):
 }
 ```
 
-# Alternatives
+## Alternatives
 
 I made this because I couldn't find a plugin that did exactly what I needed.
 
@@ -48,7 +48,7 @@ There are other plugins that tackle this, but they have their issues:
 - https://github.com/danielfalk/smart-open.nvim (depends on a sqlite database, and does not integrate with Neovim's native oldfiles)
 - https://github.com/nvim-telescope/telescope-frecency.nvim (does not seem to load the oldfiles either?)
 
-# Run on startup
+## Run on startup
 
 The first thing I do is usually open a file within the current project I'm working in.
 

--- a/lua/telescope/_extensions/recent-files.lua
+++ b/lua/telescope/_extensions/recent-files.lua
@@ -243,7 +243,7 @@ local get_absolute_path = function(path)
 end
 
 local add_trailing_separator_to_path = function(path)
-  if path:sub(#path) == utils.get_separator() then
+  if path:sub(-1) == utils.get_separator() then
     return path
   else
     return path .. utils.get_separator()

--- a/lua/telescope/_extensions/recent-files.lua
+++ b/lua/telescope/_extensions/recent-files.lua
@@ -62,6 +62,7 @@ end
 -- Copy of the builtin.oldfiles picker with the following modifications:
 -- - The final pickers.new(...):find() statement is omitted
 -- - The finder is returned instead
+-- - A fix is added for a bug that occurs when cwd is root
 local builtin_oldfiles_copy = function(opts)
   opts = apply_cwd_only_aliases(opts)
   opts.include_current_session = vim.F.if_nil(opts.include_current_session, true)
@@ -92,7 +93,9 @@ local builtin_oldfiles_copy = function(opts)
 
   if opts.cwd_only or opts.cwd then
     local cwd = opts.cwd_only and vim.loop.cwd() or opts.cwd
-    cwd = cwd .. utils.get_separator()
+    if cwd:sub(-1) ~= utils.get_separator() then
+      cwd = cwd .. utils.get_separator()
+    end
     results = vim.tbl_filter(function(file)
       return buf_in_cwd(file, cwd)
     end, results)
@@ -269,7 +272,6 @@ local recent_files = function(opts)
   -- Merge given opts with opts provided in setup()
   opts = vim.tbl_extend("force", config, opts or {})
 
-  -- BUG: Using the root directory as cwd doesn't work (builtin.oldfiles issue)
   opts.cwd = opts.cwd and get_absolute_path(opts.cwd) or vim.loop.cwd()
   opts.only_cwd = nil
   opts.cwd_only = nil

--- a/lua/telescope/_extensions/recent-files.lua
+++ b/lua/telescope/_extensions/recent-files.lua
@@ -65,7 +65,7 @@ end
 -- Copy of the builtin.oldfiles picker with the following modifications:
 -- - The final pickers.new(...):find() statement is omitted
 -- - The finder is returned instead
--- - A fix is added for a bug that occurs when cwd is root
+-- - A line is removed that stops oldfiles from working if cwd is root
 local builtin_oldfiles_copy = function(opts)
   opts = apply_cwd_only_aliases(opts)
   opts.include_current_session = vim.F.if_nil(opts.include_current_session, true)
@@ -96,9 +96,6 @@ local builtin_oldfiles_copy = function(opts)
 
   if opts.cwd_only or opts.cwd then
     local cwd = opts.cwd_only and vim.loop.cwd() or opts.cwd
-    if cwd:sub(-1) ~= utils.get_separator() then
-      cwd = cwd .. utils.get_separator()
-    end
     results = vim.tbl_filter(function(file)
       return buf_in_cwd(file, cwd)
     end, results)

--- a/lua/telescope/_extensions/recent-files.lua
+++ b/lua/telescope/_extensions/recent-files.lua
@@ -16,7 +16,7 @@ local function buf_in_cwd(bufname, cwd)
 end
 
 local function concatArray(a, b)
-  local result = {table.unpack(a)}
+  local result = { table.unpack(a) }
   table.move(b, 1, #b, #result + 1, result)
   return result
 end
@@ -174,7 +174,12 @@ local recent_files = function(opts)
 
   for _, file in ipairs(vim.v.oldfiles) do
     local file_stat = vim.loop.fs_stat(file)
-    if file_stat and file_stat.type == "file" and not vim.tbl_contains(oldfiles_table, file) and file ~= current_file then
+    if
+      file_stat
+      and file_stat.type == "file"
+      and not vim.tbl_contains(oldfiles_table, file)
+      and file ~= current_file
+    then
       table.insert(oldfiles_table, file)
     end
   end
@@ -192,8 +197,8 @@ local recent_files = function(opts)
 
   -- Remove cwd prefix from all entries in oldfiles
   oldfiles_table = vim.tbl_map(function(file)
-    return string.gsub(file, "^" .. cwd:gsub("(%W)","%%%1"), "")
-  end, oldfiles_table) 
+    return string.gsub(file, "^" .. cwd:gsub("(%W)", "%%%1"), "")
+  end, oldfiles_table)
 
   -- Remove oldfiles from findfiles
   findfiles_table = vim.tbl_filter(function(file)
@@ -203,7 +208,7 @@ local recent_files = function(opts)
   -- Remove current_file if include_current_file is false
   if not opts.include_current_file then
     local current_file = vim.fn.expand "%"
-    string.gsub(current_file, "^" .. cwd:gsub("(%W)","%%%1"), "")
+    string.gsub(current_file, "^" .. cwd:gsub("(%W)", "%%%1"), "")
 
     oldfiles_table = vim.tbl_filter(function(file)
       return file ~= current_file
@@ -249,6 +254,6 @@ return require("telescope").register_extension {
     config = ext_config or {}
   end,
   exports = {
-    recent_files = recent_files
+    recent_files = recent_files,
   },
 }

--- a/lua/telescope/_extensions/recent-files.lua
+++ b/lua/telescope/_extensions/recent-files.lua
@@ -242,8 +242,17 @@ local get_absolute_path = function(path)
   return tostring(Path:new(Path:new(path):absolute()))
 end
 
+local is_absolute_path = function(path)
+  if not utils.iswin then
+    return path:find "^/" == 1
+  else
+    path = path:gsub("/", "\\")
+    return path:find "^[a-zA-Z]:\\" == 1 or path:find "^\\\\" == 1
+  end
+end
+
 local make_relative_path = function(path, cwd_with_trailing_slash)
-  if Path:new(path):is_absolute() then
+  if is_absolute_path(path) then
     if starts_with(path, cwd_with_trailing_slash) then
       return path:sub(#cwd_with_trailing_slash + 1)
     else

--- a/lua/telescope/_extensions/recent-files.lua
+++ b/lua/telescope/_extensions/recent-files.lua
@@ -391,5 +391,11 @@ return require("telescope").register_extension {
   end,
   exports = {
     recent_files = recent_files,
+
+    -- Fix `:Telescope recent-files` command not working.
+    -- Ideally this plugin file would be renamed to recent_files.lua
+    -- and recent_files would be used everywhere, but changing that
+    -- now would break user configs.
+    ["recent-files"] = recent_files,
   },
 }

--- a/lua/telescope/_extensions/recent-files.lua
+++ b/lua/telescope/_extensions/recent-files.lua
@@ -10,6 +10,9 @@ local log = require "telescope.log"
 local async_oneshot_finder = require "telescope.finders.async_oneshot_finder"
 local flatten = utils.flatten
 
+-- Suppress LuaLS warnings about undefined fields on vim.loop
+vim.loop = vim.uv or vim.loop
+
 -- Copied from __internal.lua with no modifications
 local function apply_cwd_only_aliases(opts)
   local has_cwd_only = opts.cwd_only ~= nil


### PR DESCRIPTION
This PR rewrites the extension logic to make it run asynchronously, like builtin.find_files. This means that there shouldn't be a delay when opening the picker in large projects and you can start searching right away. Several bugs were also fixed in the process.

It works by augmenting the find_files picker to start with a list of files from the oldfiles picker, and then wrapping the entry_maker function to filter out files already seen in oldfiles.

Hope you like :)